### PR TITLE
Add options for using as a pull through cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ their default values.
 | `s3.secure`                 | Use HTTPS                                                                                  | `nil`           |
 | `swift.authurl`             | Swift authurl                                                                              | `nil`           |
 | `swift.container`           | Swift container                                                                            | `nil`           |
+| `proxy.remoteurl`           | The URL for the repository being cached                                                    | `nil`           |
+| `proxy.username`            | The username which has access to the respository                                           | `nil`           |
+| `proxy.password`            | The password to authenticate using the username specified                                  | `nil`           |
 | `nodeSelector`              | node labels for pod assignment                                                             | `{}`            |
 | `affinity`                  | affinity settings                                                                          | `{}`            |
 | `tolerations`               | pod tolerations                                                                            | `[]`            |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -154,6 +154,18 @@ spec:
             - name: REGISTRY_STORAGE_SWIFT_CONTAINER
               value: {{ required ".Values.swift.container is required" .Values.swift.container }}
 {{- end }}
+{{- if .Values.proxy.remoteurl }}
+            - name: REGISTRY_PROXY_REMOTEURL
+              value: {{ .Values.proxy.remoteurl | quote }}
+          {{- if .Values.proxy.username }}
+            - name: REGISTRY_PROXY_USERNAME
+              value: {{ .Values.proxy.username | quote }}
+          {{- end }}
+          {{- if .Values.proxy.password }}
+            - name: REGISTRY_PROXY_PASSWORD
+              value: {{ .Values.proxy.password | quote }}
+          {{- end }}
+{{- end }}
 {{- if .Values.persistence.deleteEnabled }}
             - name: REGISTRY_STORAGE_DELETE_ENABLED
               value: "true"

--- a/values.yaml
+++ b/values.yaml
@@ -97,6 +97,12 @@ secrets:
 #  authurl: http://swift.example.com/
 #  container: my-container
 
+# Options for pull through cache
+# proxy:
+#   remoteurl: https://registry-1.docker.io
+#   username: [username]
+#   password: [password]
+
 configData:
   version: 0.1
   log:


### PR DESCRIPTION
Adds the options needed to run the registry as a pull through cache as per docker's recipe.

https://docs.docker.com/registry/recipes/mirror/
