### PR TITLE
Rename port to match Istio naming conventions

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -32,7 +32,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       protocol: TCP
-      name: {{ .Values.service.name }}
+      name: http-{{ .Values.service.name }}
       targetPort: 5000
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -32,7 +32,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       protocol: TCP
-      name: http-{{ .Values.service.name }}
+      name: {{ if .Values.tlsSecretName }}https{{ else }}http{{ end }}-{{ .Values.service.port }}
       targetPort: 5000
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}


### PR DESCRIPTION
Istio requires the service port to be named like `<protocol>[-<suffix>]`.
If possible, it would be good to rename it here to match this requirement.