### PR TITLE
Allow specifying extra environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ their default values.
 | `ingress.tls`               | Ingress TLS configuration (YAML)                                                           | `[]`            |
 | `extraVolumeMounts`         | Additional volumeMounts to the registry container                                          | `[]`            |
 | `extraVolumes`              | Additional volumes to the pod                                                              | `[]`            |
+| `extraEnv`                  | Additional environment variables for the registry container                                | `[]`            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -158,6 +158,9 @@ spec:
             - name: REGISTRY_STORAGE_DELETE_ENABLED
               value: "true"
 {{- end }}
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 12 }}
+{{- end }}
           volumeMounts:
 {{- if .Values.secrets.htpasswd }}
             - name: auth

--- a/values.yaml
+++ b/values.yaml
@@ -147,3 +147,8 @@ extraVolumes: []
 #        - key: cloudfront.pem
 #          path: cloudfront.pem
 #          mode: 511
+
+extraEnv: []
+## Additional environment variables for the registry container.
+#  - name: REGISTRY_HTTP_ADDR
+#    value: "0.0.0.0:5000"


### PR DESCRIPTION
The registry image has a bunch of configuration provided through environment variables that isn't covered by the chart values.
It doesn't really make sense to try and cover everything through values, so we should allow users to specify additional environment variables.
