### PR TITLE
Add support for service.externalIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ their default values.
 | `service.port`              | TCP port on which the service is exposed                                                   | `5000`          |
 | `service.type`              | service type                                                                               | `ClusterIP`     |
 | `service.clusterIP`         | if `service.type` is `ClusterIP` and this is non-empty, sets the cluster IP of the service | `nil`           |
+| `service.externalIPs`       | if `service.externalIPs` is non-empty, sets the external IP(s) of the service              | `nil`           |
 | `service.nodePort`          | if `service.type` is `NodePort` and this is non-empty, sets the node port of the service   | `nil`           |
 | `service.loadBalancerIP`     | if `service.type` is `LoadBalancer` and this is non-empty, sets the loadBalancerIP of the service | `nil`          |
 | `service.loadBalancerSourceRanges`| if `service.type` is `LoadBalancer` and this is non-empty, sets the loadBalancerSourceRanges of the service | `nil`           |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -16,6 +16,12 @@ spec:
 {{- if (and (eq .Values.service.type "ClusterIP") (not (empty .Values.service.clusterIP))) }}
   clusterIP: {{ .Values.service.clusterIP }}
 {{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+    {{- range .Values.service.externalIPs }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end }}
 {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,7 @@ service:
   # sessionAffinity: None
   # sessionAffinityConfig: {}
   # clusterIP:
+  # externalIPs: []
   port: 5000
   # nodePort:
   # loadBalancerIP:


### PR DESCRIPTION
This PR adds the ability to define externalIPs for the service, which is useful for situations where load balancers are not available. 

Our use case is a single node cluster, which with an externalIP enables us to pull and push images without having to resort to using a nodePort, which does not work well with rolling updates. 