### PR TITLE
Add support for registry proxy/mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ their default values.
 | `s3.secure`                 | Use HTTPS                                                                                  | `nil`           |
 | `swift.authurl`             | Swift authurl                                                                              | `nil`           |
 | `swift.container`           | Swift container                                                                            | `nil`           |
+| `proxy.enabled`             | If true, registry will function as a proxy/mirror                                          | `false`         |
+| `proxy.remoteurl`           | Remote registry URL to proxy requests to                                                   | `https://registry-1.docker.io`            |
+| `proxy.username`            | Remote registry login username                                                             | `nil`           |
+| `proxy.password`            | Remote registry login password                                                             | `nil`           |
 | `nodeSelector`              | node labels for pod assignment                                                             | `{}`            |
 | `affinity`                  | affinity settings                                                                          | `{}`            |
 | `tolerations`               | pod tolerations                                                                            | `[]`            |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -154,6 +154,20 @@ spec:
             - name: REGISTRY_STORAGE_SWIFT_CONTAINER
               value: {{ required ".Values.swift.container is required" .Values.swift.container }}
 {{- end }}
+{{- if .Values.proxy.enabled }}
+            - name: REGISTRY_PROXY_REMOTEURL
+              value: {{ required ".Values.proxy.remoteurl is required" .Values.proxy.remoteurl }}
+            - name: REGISTRY_PROXY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: proxyUsername
+            - name: REGISTRY_PROXY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docker-registry.fullname" . }}-secret
+                  key: proxyPassword
+{{- end }}
 {{- if .Values.persistence.deleteEnabled }}
             - name: REGISTRY_STORAGE_DELETE_ENABLED
               value: "true"

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -35,3 +35,10 @@ data:
   swiftPassword: {{ .Values.secrets.swift.password | b64enc | quote }}
     {{- end }}
   {{- end }}
+  
+  {{- if .Values.proxy.username }}
+  proxyUsername: {{ .Values.proxy.username | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.proxy.password }}
+  proxyPassword: {{ .Values.proxy.password | b64enc | quote }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -97,6 +97,13 @@ secrets:
 #  authurl: http://swift.example.com/
 #  container: my-container
 
+# https://docs.docker.com/registry/recipes/mirror/
+proxy:
+  enabled: false
+  remoteurl: https://registry-1.docker.io
+  username: ""
+  password: ""
+
 configData:
   version: 0.1
   log:


### PR DESCRIPTION
This pull request adds support for configuring the registry as a proxy or pull-through cache, as documented [here](https://docs.docker.com/registry/recipes/mirror/). 

My use case for this configuration is to avoid [pull rate limits](https://docs.docker.com/docker-hub/download-rate-limit/) in kubernetes clusters where one may be deploying multiple applications at once such as after a cluster is initially created or when testing different configurations of an application, requiring multiple deployments. 