### PR TITLE
Add support for having external proxy secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ their default values.
 | `proxy.remoteurl`           | Remote registry URL to proxy requests to                                                   | `https://registry-1.docker.io`            |
 | `proxy.username`            | Remote registry login username                                                             | `nil`           |
 | `proxy.password`            | Remote registry login password                                                             | `nil`           |
+| `proxy.secretRef`           | The ref for an external secret containing the proxyUsername and proxyPassword keys         | `""`            |
 | `nodeSelector`              | node labels for pod assignment                                                             | `{}`            |
 | `affinity`                  | affinity settings                                                                          | `{}`            |
 | `tolerations`               | pod tolerations                                                                            | `[]`            |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -160,12 +160,12 @@ spec:
             - name: REGISTRY_PROXY_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "docker-registry.fullname" . }}-secret
+                  name: {{ if .Values.proxy.secretRef }}{{ .Values.proxy.secretRef }}{{ else }}{{ template "docker-registry.fullname" . }}-secret{{ end }}
                   key: proxyUsername
             - name: REGISTRY_PROXY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "docker-registry.fullname" . }}-secret
+                  name: {{ if .Values.proxy.secretRef }}{{ .Values.proxy.secretRef }}{{ else }}{{ template "docker-registry.fullname" . }}-secret{{ end }}
                   key: proxyPassword
 {{- end }}
 {{- if .Values.persistence.deleteEnabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -103,6 +103,9 @@ proxy:
   remoteurl: https://registry-1.docker.io
   username: ""
   password: ""
+  # the ref for a secret stored outside of this chart
+  # Keys: proxyUsername, proxyPassword
+  secretRef: ""
 
 configData:
   version: 0.1


### PR DESCRIPTION
When using GitOps tools like Flux, we don't want the contents of values.yaml to be added to Git.
 As such, it is desirable to load them from secrets created a priori.

 This PR adds support for this, on the proxy config, through a `authExternalSecret` key that refs a specific secret in order to fulfill this usecase.

 Let me know if this makes sense :)