### PR TITLE
Corrected docker htpasswd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,6 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.
 
 To generate htpasswd file, run this docker command:
-`docker run --entrypoint htpasswd registry:2 -Bbn user password > ./htpasswd`.
+``` 
+docker run --entrypoint htpasswd httpd:2 -Bbn user password > ./htpasswd
+``` 


### PR DESCRIPTION
Current command does not work anymore - probably due to changes in underlying image. New comes from official docker documentation and works fine.