### PR TITLE
Add support for having external s3 secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ their default values.
 | `secrets.htpasswd`          | Htpasswd authentication                                                                    | `nil`           |
 | `secrets.s3.accessKey`      | Access Key for S3 configuration                                                            | `nil`           |
 | `secrets.s3.secretKey`      | Secret Key for S3 configuration                                                            | `nil`           |
+| `secrets.s3.secretRef`      | The ref for an external secret containing the accessKey and secretKey keys                 | `""`            |
 | `secrets.swift.username`    | Username for Swift configuration                                                           | `nil`           |
 | `secrets.swift.password`    | Password for Swift configuration                                                           | `nil`           |
 | `haSharedSecret`            | Shared secret for Registry                                                                 | `nil`           |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -110,16 +110,16 @@ spec:
                   name: {{ template "docker-registry.fullname" . }}-secret
                   key: azureContainer
 {{- else if eq .Values.storage "s3" }}
-            {{- if and .Values.secrets.s3.secretKey .Values.secrets.s3.accessKey }}
+            {{- if or (and .Values.secrets.s3.secretKey .Values.secrets.s3.accessKey) .Values.secrets.s3.secretRef }}
             - name: REGISTRY_STORAGE_S3_ACCESSKEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "docker-registry.fullname" . }}-secret
+                  name: {{ if .Values.secrets.s3.secretRef }}{{ .Values.secrets.s3.secretRef }}{{ else }}{{ template "docker-registry.fullname" . }}-secret{{ end }}
                   key: s3AccessKey
             - name: REGISTRY_STORAGE_S3_SECRETKEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "docker-registry.fullname" . }}-secret
+                  name: {{ if .Values.secrets.s3.secretRef }}{{ .Values.secrets.s3.secretRef }}{{ else }}{{ template "docker-registry.fullname" . }}-secret{{ end }}
                   key: s3SecretKey
             {{- end }}
             - name: REGISTRY_STORAGE_S3_REGION

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,9 @@ secrets:
 #     accountKey: ""
 #     container: ""
 # Secrets for S3 access and secret keys
+# Use a secretRef with keys (accessKey, secretKey) for secrets stored outside the chart
 #   s3:
+#     secretRef: ""
 #     accessKey: ""
 #     secretKey: ""
 # Secrets for Swift username and password


### PR DESCRIPTION
Following the rationale on https://github.com/twuni/docker-registry.helm/pull/20, this PR adds support for externalizing s3 secrets.

Let me know if the changes make sense :)