### PR TITLE
Add keys proxyUsername and proxyPassword with empty string to docker-registry-secret if values are not set

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -38,7 +38,11 @@ data:
   
   {{- if .Values.proxy.username }}
   proxyUsername: {{ .Values.proxy.username | b64enc | quote }}
+  {{- else }}
+  proxyUsername: ""
   {{- end }}
   {{- if .Values.proxy.password }}
   proxyPassword: {{ .Values.proxy.password | b64enc | quote }}
+  {{- else }}
+  proxyPassword: ""
   {{- end }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -35,14 +35,5 @@ data:
   swiftPassword: {{ .Values.secrets.swift.password | b64enc | quote }}
     {{- end }}
   {{- end }}
-  
-  {{- if .Values.proxy.username }}
-  proxyUsername: {{ .Values.proxy.username | b64enc | quote }}
-  {{- else }}
-  proxyUsername: ""
-  {{- end }}
-  {{- if .Values.proxy.password }}
-  proxyPassword: {{ .Values.proxy.password | b64enc | quote }}
-  {{- else }}
-  proxyPassword: ""
-  {{- end }}
+  proxyUsername: {{ .Values.proxy.username | default "" | b64enc | quote }}
+  proxyPassword: {{ .Values.proxy.password | default "" | b64enc | quote }}


### PR DESCRIPTION
Setting up docker-registry proxy with no password & username created the secret without `proxyUsername` and `proxyPassword` fields, causing pod to fail if `proxy.enabled = true` with error 
```
error: "couldn't find key proxyUsername in Secret <namespace>/docker-registry-secret"
```