### PR TITLE
Fix for issue number 19, ingress current api version and previous api version…

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
+{{- $apiVersion := .Capabilities.APIVersions -}}
 {{- $serviceName := include "docker-registry.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
-{{- $apiVersion := .Capabilities.APIVersions -}}
 {{- $path := .Values.ingress.path -}}
 apiVersion: {{- if $apiVersion.Has "networking.k8s.io/v1" }} networking.k8s.io/v1 {{- else }} networking.k8s.io/v1beta1 {{- end }}
 kind: Ingress

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+{{- if $apiVersion.Has "networking.k8s.io/v1" }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "docker-registry.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $path := .Values.ingress.path -}}
-apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else }} extensions/v1beta1 {{- end }}
+apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }} networking.k8s.io/v1 {{- else }} networking.k8s.io/v1beta1 {{- end }}
 kind: Ingress
 metadata:
   name: {{ template "docker-registry.fullname" . }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -25,9 +25,18 @@ spec:
       http:
         paths:
           - path: {{ $path }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+{{- else }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+{{- end }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "docker-registry.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
+{{- $apiVersion := .Capabilities.APIVersions -}}
 {{- $path := .Values.ingress.path -}}
-apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }} networking.k8s.io/v1 {{- else }} networking.k8s.io/v1beta1 {{- end }}
+apiVersion: {{- if $apiVersion.Has "networking.k8s.io/v1" }} networking.k8s.io/v1 {{- else }} networking.k8s.io/v1beta1 {{- end }}
 kind: Ingress
 metadata:
   name: {{ template "docker-registry.fullname" . }}
@@ -25,7 +26,7 @@ spec:
       http:
         paths:
           - path: {{ $path }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $apiVersion.Has "networking.k8s.io/v1" }}
             pathType: Prefix
             backend:
               service:

--- a/values.yaml
+++ b/values.yaml
@@ -32,6 +32,7 @@ service:
   # foo.io/bar: "true"
 ingress:
   enabled: false
+  ingressClassName: nginx
   path: /
   # Used to create an Ingress record.
   hosts:


### PR DESCRIPTION
The current version of kubernetes is unable to install this helm chart.  Update Ingress api version to the current stable version used by kubernetes 1.22.*.  Update the else version to use the previous beta version.