### PR TITLE
Add support for S3 bucket data prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ their default values.
 | `s3.region`                 | S3 region                                                                                  | `nil`           |
 | `s3.regionEndpoint`         | S3 region endpoint                                                                         | `nil`           |
 | `s3.bucket`                 | S3 bucket name                                                                             | `nil`           |
+| `s3.rootdirectory`          | S3 prefix that is applied to allow you to segment data                                     | `nil`           |
 | `s3.encrypt`                | Store images in encrypted format                                                           | `nil`           |
 | `s3.secure`                 | Use HTTPS                                                                                  | `nil`           |
 | `swift.authurl`             | Swift authurl                                                                              | `nil`           |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -130,6 +130,10 @@ spec:
           {{- end }}
             - name: REGISTRY_STORAGE_S3_BUCKET
               value: {{ required ".Values.s3.bucket is required" .Values.s3.bucket }}
+          {{- if .Values.s3.rootdirectory }}
+            - name: REGISTRY_STORAGE_S3_ROOTDIRECTORY
+              value: {{ .Values.s3.rootdirectory | quote }}
+          {{- end }}
           {{- if .Values.s3.encrypt }}
             - name: REGISTRY_STORAGE_S3_ENCRYPT
               value: {{ .Values.s3.encrypt | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -91,6 +91,7 @@ secrets:
 #  region: us-east-1
 #  regionEndpoint: s3.us-east-1.amazonaws.com
 #  bucket: my-bucket
+#  rootdirectory: /object/prefix
 #  encrypt: false
 #  secure: true
 


### PR DESCRIPTION
Add support for S3 bucket to prefix all data

https://docs.docker.com/registry/storage-drivers/s3/
> This is a prefix that is applied to all S3 keys to allow you to segment data in your bucket if necessary.