### PR TITLE
Add metrics config

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -22,3 +22,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Extract port from host:port
+*/}}
+{{- define "split-host-port" -}}
+{{- $hp := split ":" . -}}
+{{- printf "%s" $hp._1 -}}
+{{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -54,6 +54,11 @@ spec:
           - /etc/docker/registry/config.yml
           ports:
             - containerPort: 5000
+{{- if .Values.configData.http.debug.prometheus.enabled }}
+            - containerPort: {{ include "split-host-port" .Values.configData.http.debug.addr }}
+              name: metrics
+              protocol: TCP
+{{- end }}
           livenessProbe:
             httpGet:
 {{- if .Values.tlsSecretName }}

--- a/templates/service-metrics.yaml
+++ b/templates/service-metrics.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.configData.http.debug.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "docker-registry.fullname" . }}-metrics
+  labels:
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ include "split-host-port" .Values.configData.http.debug.addr }}
+      protocol: TCP
+      name: metrics
+      targetPort: {{ include "split-host-port" .Values.configData.http.debug.addr }}
+  selector:
+    app: {{ template "docker-registry.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -121,6 +121,13 @@ configData:
     addr: :5000
     headers:
       X-Content-Type-Options: [nosniff]
+    ## https://docs.docker.com/registry/configuration/#debug
+    ## to enable metrics set debug.prometheus.enabled true
+    debug:
+      addr: :5001
+      prometheus:
+        enabled: false
+        path: /metrics
   health:
     storagedriver:
       enabled: true


### PR DESCRIPTION
- metrics not added to Readme as configData is described as nil
- service-metrics as separate service with explicit Type: ClusterIP to not expose it automatically if user uses NodePort in custom service configuration
- debug server is on by default but it is not exposed (only if configData.http.debug.prometheus.enabled is true)
