### PR TITLE
Add minimal config to enable metrics

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -54,6 +54,11 @@ spec:
           - /etc/docker/registry/config.yml
           ports:
             - containerPort: 5000
+{{- if .Values.configData.http.debug.prometheus.enabled }}
+            - containerPort: {{ (split ":" .Values.configData.http.debug.addr)._1 }}
+              name: metrics
+              protocol: TCP
+{{- end }}
           livenessProbe:
             httpGet:
 {{- if .Values.tlsSecretName }}

--- a/values.yaml
+++ b/values.yaml
@@ -122,8 +122,6 @@ configData:
     addr: :5000
     headers:
       X-Content-Type-Options: [nosniff]
-    ## https://docs.docker.com/registry/configuration/#debug
-    ## to enable metrics set debug.prometheus.enabled true
     debug:
       addr: :5001
       prometheus:

--- a/values.yaml
+++ b/values.yaml
@@ -122,6 +122,13 @@ configData:
     addr: :5000
     headers:
       X-Content-Type-Options: [nosniff]
+    ## https://docs.docker.com/registry/configuration/#debug
+    ## to enable metrics set debug.prometheus.enabled true
+    debug:
+      addr: :5001
+      prometheus:
+        enabled: false
+        path: /metrics
   health:
     storagedriver:
       enabled: true


### PR DESCRIPTION
- The default configData configuration enables the debug server but does not expose it. 
- The user can enable metrics by setting configData.http.debug.prometheus.enabled:=true
- If metrics is enabled the metrics port (default 5001) gets exposed by the pod. 
- The service and service-monitor configuration is left to the user (for simplicity and security)