### PR TITLE
Add support to overwrite storage path

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -184,7 +184,7 @@ spec:
 {{- end }}
 {{- if eq .Values.storage "filesystem" }}
             - name: data
-              mountPath: /var/lib/registry/
+              mountPath: {{ .Values.storagePath | default "/var/lib/registry/" | quote }}
 {{- end }}
             - name: "{{ template "docker-registry.fullname" . }}-config"
               mountPath: "/etc/docker/registry"

--- a/values.yaml
+++ b/values.yaml
@@ -64,6 +64,7 @@ persistence:
 
 # set the type of filesystem to use: filesystem, s3
 storage: filesystem
+storagePath: "/mnt/example"
 
 # Set this to name of secret for tls certs
 # tlsSecretName: registry.docker.example.com


### PR DESCRIPTION
This PR makes it possible to configure the storage path instead of hard-coding it to `/var/lib/registry`.