### PR TITLE
Enable metrics via Prometheus Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ their default values.
 | `ingress.path`              | Ingress service path                                                                       | `/`             |
 | `ingress.hosts`             | Ingress hostnames                                                                          | `[]`            |
 | `ingress.tls`               | Ingress TLS configuration (YAML)                                                           | `[]`            |
-| `metrics.enable`            | Enable metrics on Service                                                                  | `false`         |
+| `metrics.enabled`           | Enable metrics on Service                                                                  | `false`         |
 | `metrics.port`              | TCP port on which the service metrics is exposed                                           | `5001`          |
 | `metrics.serviceMonitor.annotations` | Prometheus Operator ServiceMonitor annotations                                    | `{}`            |
 | `metrics.serviceMonitor.enable` | If true, Prometheus Operator ServiceMonitor will be created                            | `false`         |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ their default values.
 | `ingress.path`              | Ingress service path                                                                       | `/`             |
 | `ingress.hosts`             | Ingress hostnames                                                                          | `[]`            |
 | `ingress.tls`               | Ingress TLS configuration (YAML)                                                           | `[]`            |
+| `metrics.enable`            | Enable metrics on Service                                                                  | `false`         |
+| `metrics.port`              | TCP port on which the service metrics is exposed                                           | `5001`          |
+| `metrics.serviceMonitor.annotations` | Prometheus Operator ServiceMonitor annotations                                    | `{}`            |
+| `metrics.serviceMonitor.enable` | If true, Prometheus Operator ServiceMonitor will be created                            | `false`         |
+| `metrics.serviceMonitor.labels` | Prometheus Operator ServiceMonitor labels                                              | `{}`            |
+| `metrics.prometheusRule.annotations` | Prometheus Operator PrometheusRule annotations                                    | `{}`            |
+| `metrics.prometheusRule.enable` | If true, Prometheus Operator prometheusRule will be created                            | `false`         |
+| `metrics.prometheusRule.labels` | Prometheus Operator prometheusRule labels                                              | `{}`            |
+| `metrics.prometheusRule.rules` | PrometheusRule defining alerting rules for a Prometheus instance                        | `{}`            |
 | `extraVolumeMounts`         | Additional volumeMounts to the registry container                                          | `[]`            |
 | `extraVolumes`              | Additional volumes to the pod                                                              | `[]`            |
 | `extraEnvVars`              | Additional environment variables to the pod                                                | `[]`            |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -54,6 +54,11 @@ spec:
           - /etc/docker/registry/config.yml
           ports:
             - containerPort: 5000
+{{- if .Values.metrics.enabled }}
+            - containerPort: {{ (split ":" .Values.configData.http.debug.addr)._1 }}
+              name: metrics
+              protocol: TCP
+{{- end }}
           livenessProbe:
             httpGet:
 {{- if .Values.tlsSecretName }}

--- a/templates/prometheusrules.yaml
+++ b/templates/prometheusrules.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "docker-registry.fullname" . }}
+  labels:
+    app.kubernetes.io/component: controller
+  {{- if .Values.metrics.prometheusRule.labels }}
+    {{- toYaml .Values.metrics.prometheusRule.labels | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.metrics.prometheusRule.rules }}
+  groups:
+  - name: {{ template "docker-registry.fullname" . }}
+    rules: {{- toYaml .Values.metrics.prometheusRule.rules | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -37,6 +37,12 @@ spec:
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
 {{- end }}
+{{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.port }}
+      protocol: TCP
+      name: metrics
+      targetPort: {{ (split ":" .Values.configData.http.debug.addr)._1 }}
+{{- end }}
   selector:
     app: {{ template "docker-registry.name" . }}
     release: {{ .Release.Name }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "docker-registry.fullname" . }}-servicemonitor
+  labels:
+    app: {{ template "docker-registry.name" . }}-metrics
+    release: {{ .Release.Name }}
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "docker-registry.name" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+  endpoints:
+  - port: metrics
+    interval: 15s
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -110,6 +110,19 @@ proxy:
   # Keys: proxyUsername, proxyPassword
   secretRef: ""
 
+metrics:
+  enable: false
+  port: 5001
+  # Create a prometheus-operator servicemonitor
+  serviceMonitor:
+    enabled: false
+    labels: {}
+  # prometheus-operator PrometheusRule defining alerting rules for a Prometheus instance
+  prometheusRule:
+    enabled: false
+    labels: {}
+    rules: {}
+
 configData:
   version: 0.1
   log:
@@ -122,6 +135,11 @@ configData:
     addr: :5000
     headers:
       X-Content-Type-Options: [nosniff]
+    debug:
+      addr: :5001
+      prometheus:
+        enabled: false
+        path: /metrics
   health:
     storagedriver:
       enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ proxy:
   secretRef: ""
 
 metrics:
-  enable: false
+  enabled: false
   port: 5001
   # Create a prometheus-operator servicemonitor
   serviceMonitor:


### PR DESCRIPTION
Added support to enable metrics of docker-registry and enabled integration with Prometheus Operator (https://github.com/prometheus-operator/prometheus-operator)

This enables metrics and native seamless integration of docker-registry setup with Prometheus Operator. This functionality enables both passing of metrics and alert configuration to Prometheus. This functionality is by default disable and user can enable it.

Specification if metrics are enabled:
- Metrics are be exposed on Pod and Service. 
- Pod port for metrics is set via `configData` while port for Service is set via values ( `.Values.metrics.port` )
- ServiceMonitor and PrometheusRule are deployed which are part of Prometheus Operator `monitoring.coreos.com/v1`

Credits for exposing metrics: https://github.com/twuni/docker-registry.helm/pull/32

Example of configuration (Values.yaml) with enabled metrics and Alerts would look like:

```
....
metrics:
  enabled: true
  serviceMonitor:
    enabled: true
    labels:
      prometheus: prometheus
  prometheusRule:
    enabled: true
    labels :
      prometheus: prometheus
    rules:
      - alert: TooMany400s
        annotations:
          description: Too many 4XXs
          summary: More than 5% of the all requests did return 4XX, this requires your
            attention
        expr: 100 * ( sum( registry_http_requests_total{code=~"4.+"} ) / sum(registry_http_requests_total)
          ) > 5
        for: 1m
        labels:
          severity: critical 
....
```