### PR TITLE
Add initContainer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ their default values.
 | `extraVolumeMounts`         | Additional volumeMounts to the registry container                                          | `[]`            |
 | `extraVolumes`              | Additional volumes to the pod                                                              | `[]`            |
 | `extraEnvVars`              | Additional environment variables to the pod                                                | `[]`            |
+| `initContainers`            | Init containers to be created in the pod                                                   | `[]`            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
 {{- end }}
+{{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/values.yaml
+++ b/values.yaml
@@ -165,3 +165,9 @@ extraEnvVars: []
 ## Additional ENV variables to set
 # - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
 #   value: "/var/lib/example"
+
+initContainers: []
+## Init containers to add to the Deployment
+# - name: init
+#   image: busybox
+#   command: []


### PR DESCRIPTION
This commit will give the user the ability to specify initContainers directly in the values file, which will then become part of the deployment.