### PR TITLE
Support deployment to a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ their default values.
 | `proxy.username`            | Remote registry login username                                                             | `nil`           |
 | `proxy.password`            | Remote registry login password                                                             | `nil`           |
 | `proxy.secretRef`           | The ref for an external secret containing the proxyUsername and proxyPassword keys         | `""`            |
+| `namespace`                 | specify a namespace to install the chart to - defaults to `.Release.Namespace`             | `{{ .Release.Namespace }}` |
 | `nodeSelector`              | node labels for pod assignment                                                             | `{}`            |
 | `affinity`                  | affinity settings                                                                          | `{}`            |
 | `tolerations`               | pod tolerations                                                                            | `[]`            |

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "docker-registry.fullname" . }}-config
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} 
 kind: Ingress
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/templates/poddisruptionbudget.yaml
+++ b/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "docker-registry.fullname" . }}-secret
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "docker-registry.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
The charts didn't specify `metadata.namespace` anywhere so have added support for this. Have used the `{{ .Release.Namespace }}` variable which defaults to `default` if not set. This makes it a non-intrusive change for anyone not wanting to use it, but a useful change for those who do

Fixed #41

Have tested against my own cluster with these commands:

## Default namespace

```shell
helm upgrade \
  --atomic \
  --cleanup-on-fail \
  --install \
  --wait \
  registry .
```

This deploys `registry` to `default` namespace

## Custom namespace

```shell
helm upgrade \
  --atomic \
  --cleanup-on-fail \
  --create-namespace \
  --install \
  --namespace registry \
  --wait \
  registry .
```

This deploys `registry` to `registry` namespace