### PR TITLE
🌐 make protocol selection work with istio

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - containerPort: 5000
 {{- if .Values.metrics.enabled }}
             - containerPort: {{ (split ":" .Values.configData.http.debug.addr)._1 }}
-              name: metrics
+              name: http-metrics
               protocol: TCP
 {{- end }}
           livenessProbe:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -41,7 +41,7 @@ spec:
 {{- if .Values.metrics.enabled }}
     - port: {{ .Values.metrics.port }}
       protocol: TCP
-      name: metrics
+      name: http-metrics
       targetPort: {{ (split ":" .Values.configData.http.debug.addr)._1 }}
 {{- end }}
   selector:

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -16,6 +16,6 @@ spec:
       release: {{ .Release.Name }}
       heritage: {{ .Release.Service }}
   endpoints:
-  - port: metrics
+  - port: http-metrics
     interval: 15s
 {{- end }}


### PR DESCRIPTION
Quick PR that renames the metrics port from `metrics` to `http-metrics` to make scraping work automatically with Istio protocol selection: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/

We can also avoid renaming the port by means of using `appProtocol` on the Service Port spec, but figured if this was viable it works across a wider set of K8S versions.