### PR TITLE
Lookup randomly generated haSharedSecret

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -16,9 +16,14 @@ data:
   {{- if .Values.secrets.haSharedSecret }}
   haSharedSecret: {{ .Values.secrets.haSharedSecret | b64enc | quote }}
   {{- else }}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "docker-registry.fullname" .)) }}
+    {{- if (dig "data" "haSharedSecret" "" $secret) }}
+  haSharedSecret: {{ $secret.data.haSharedSecret | quote }}
+    {{- else }}
   haSharedSecret: {{ randAlphaNum 16 | b64enc | quote }}
+    {{- end }}
   {{- end }}
-  
+
   {{- if eq .Values.storage "azure" }}
     {{- if and .Values.secrets.azure.accountName .Values.secrets.azure.accountKey .Values.secrets.azure.container }}
   azureAccountName: {{ .Values.secrets.azure.accountName | b64enc | quote }}


### PR DESCRIPTION
If haSharedSecret is not defined an existing value on the running
cluster will be reused before generating a random value, preventing
deployments from needlessly rolling on upgrade. The secret can still be
explicitly rotated with "--set secrets.haSharedSecret".