### PR TITLE
feat: add logic to support custom liveness and readiness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ their default values.
 | `extraVolumeMounts`         | Additional volumeMounts to the registry container                                          | `[]`            |
 | `extraVolumes`              | Additional volumes to the pod                                                              | `[]`            |
 | `extraEnvVars`              | Additional environment variables to the pod                                                | `[]`            |
+| `livenessProbe`             | Optional livenessProbe definition                                                          | `nil`           |
+| `readinessProbe`            | Optional readinessProbe definition                                                         | `nil`           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -22,3 +22,41 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a livenessProbe.
+Allow the default value to be completely overriden by an optional value.
+Retain he original livenessProbe logic.
+*/}}
+{{- define "livenessProbe" -}}
+livenessProbe:
+{{- if .Values.livenessProbe }}
+{{ .Values.livenessProbe | toYaml | indent 2 }}
+{{- else }}
+  httpGet:
+{{- if .Values.tlsSecretName }}
+    scheme: HTTPS
+{{- end }}
+    path: /
+    port: 5000
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a readinessProbe.
+Allow the default value to be completely overriden by an optional value.
+Retain he original readinessProbe logic.
+*/}}
+{{- define "readinessProbe" -}}
+readinessProbe:
+{{- if .Values.readinessProbe }}
+{{ .Values.readinessProbe | toYaml | indent 2 }}
+{{- else }}
+  httpGet:
+{{- if .Values.tlsSecretName }}
+    scheme: HTTPS
+{{- end }}
+    path: /
+    port: 5000
+{{- end -}}
+{{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -64,20 +64,8 @@ spec:
               name: http-metrics
               protocol: TCP
 {{- end }}
-          livenessProbe:
-            httpGet:
-{{- if .Values.tlsSecretName }}
-              scheme: HTTPS
-{{- end }}
-              path: /
-              port: 5000
-          readinessProbe:
-            httpGet:
-{{- if .Values.tlsSecretName }}
-              scheme: HTTPS
-{{- end }}
-              path: /
-              port: 5000
+{{ include "livenessProbe" . | indent 10 }}
+{{ include "readinessProbe" . | indent 10 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:

--- a/values.yaml
+++ b/values.yaml
@@ -168,8 +168,8 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 2
   targetCPUUtilizationPercentage: 60
-  targetMemoryUtilizationPercentage: 60 # available only on Kubernetes ≥1.23 [required "autoscaling/v2"]
-  behavior: {} # available only on Kubernetes ≥1.23 [required "autoscaling/v2"]
+  targetMemoryUtilizationPercentage: 60  # available only on Kubernetes ≥1.23 [required "autoscaling/v2"]
+  behavior: {}  # available only on Kubernetes ≥1.23 [required "autoscaling/v2"]
 #   scaleDown:
 #     stabilizationWindowSeconds: 300
 #     policies:
@@ -213,3 +213,13 @@ extraEnvVars: []
 ## Additional ENV variables to set
 # - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
 #   value: "/var/lib/example"
+
+# # Custom LivenessProbe config to override default
+# livenessProbe:
+#   tcpSocket:
+#     port: 5000
+
+# # Custom readinessProbe config to override default
+# readinessProbe:
+#   tcpSocket:
+#     port: 5000


### PR DESCRIPTION
Closes #54

Retains current liveness and readiness probe logic while adding the ability to override the defaults.