### PR TITLE
Fix reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ their default values.
 | `secrets.s3.secretRef`      | The ref for an external secret containing the accessKey and secretKey keys                 | `""`            |
 | `secrets.swift.username`    | Username for Swift configuration                                                           | `nil`           |
 | `secrets.swift.password`    | Password for Swift configuration                                                           | `nil`           |
-| `haSharedSecret`            | Shared secret for Registry                                                                 | `nil`           |
+| `secrets.haSharedSecret`    | Shared secret for Registry                                                                 | `nil`           |
 | `configData`                | Configuration hash for docker                                                              | `nil`           |
 | `s3.region`                 | S3 region                                                                                  | `nil`           |
 | `s3.regionEndpoint`         | S3 region endpoint                                                                         | `nil`           |


### PR DESCRIPTION
https://github.com/twuni/docker-registry.helm/blob/f1583238750b54247c32b3d7cc1e6b72c0dbdc8c/templates/secret.yaml#L17

According to `secret.yaml` `haSharedSecret` should be inside `secrets` object