### PR TITLE
🐞 Add missing namespace to ServiceAccount

### DIFF
--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- if .Values.serviceAccount.name }}
   name: {{ .Values.serviceAccount.name }}
 {{- else  }}


### PR DESCRIPTION
When `serviceAccount.create` is `true`, this chart creates
a service account. Currently, that service account will be
created without an explicit namespace. This can be problematic
because the Deployment resource does have an explicit namespace
set. Because the ServiceAccount and Deployment (ultimately, the
Pod) must coexist in the same namespace, we need to follow the
same logic when setting the namespace for both.

Intended to fix https://github.com/twuni/docker-registry.helm/issues/60.

See https://github.com/twuni/docker-registry.helm/blob/main/templates/deployment.yaml#L5 and https://github.com/twuni/docker-registry.helm/blob/main/templates/secret.yaml#L5 for reference on how the namespace is being set in these other resources.