### PR TITLE
Keep images volume by default

### DIFF
--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 metadata:
   name: {{ template "docker-registry.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
+  {{- if .Values.persistence.keep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     app: {{ template "docker-registry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/values.yaml
+++ b/values.yaml
@@ -65,6 +65,7 @@ resources: {}
 persistence:
   accessMode: 'ReadWriteOnce'
   enabled: false
+  keep: true
   size: 10Gi
   # storageClass: '-'
 


### PR DESCRIPTION
This commit sets the `helm.sh/resource-policy` annotation [0] of the `PersistentVolumeClaim` to `"keep"` if the `persistence.keep` value is true (the default).

This makes it so the persistent volume claim is not destroyed when the chart is uninstalled.  This saves people from accidentally destroying their entire volume of images whenever they, for example, want to move the chart to a different namespace (which requires uninstalling and reinstalling the chart in the new namespace because the namespace field is immutable).

Several other big-name charts use a `"keep"` resource policy for similar reasons (see [1] and [2]).

If the user still wants their PVC to be destroyed, then can either set `persistence.keep` to `false` or manually delete it after an uninstall.  The helm CLI alerts the user when objects are left around after the chart is uninstalled.

[0]: https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource
[1]: https://github.com/traefik/traefik-helm-chart/blob/v10.24.0/traefik/templates/pvc.yaml#L10
[2]: https://github.com/argoproj/argo-helm/blob/argo-cd-5.3.6/charts/argo-cd/templates/crds/crd-application.yaml#L7