### PR TITLE
feat: add statefuleset support on v2.2.2

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -187,7 +187,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
       path: htpasswd
 {{- end }}
 
-{{- if eq .Values.storage "filesystem" }}
+{{- if (and (eq .Values.storage "filesystem") (not .Values.useStatefulSet)) }}
 - name: data
   {{- if .Values.persistence.enabled }}
   persistentVolumeClaim:

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.persistence.enabled }}
-{{- if not .Values.persistence.existingClaim -}}
+{{- if (not .Values.useStatefulSet) }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "pvc")}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -24,4 +24,4 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end -}}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -1,8 +1,3 @@
-# File              : statefulset.yaml
-# Author            : TheDetective
-# Date              : 28.11.2022
-# Last Modified Date: 28.11.2022
-# Last Modified By  : TheDetective
 {{- $sts := list "sts" "StatefulSet" -}}
 {{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (has .Values.persistence.type $sts)))}}
 apiVersion: apps/v1

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -1,6 +1,12 @@
-{{- if (and (not .Values.useStatefulSet) (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc"))) }}
+# File              : statefulset.yaml
+# Author            : TheDetective
+# Date              : 28.11.2022
+# Last Modified Date: 28.11.2022
+# Last Modified By  : TheDetective
+{{- $sts := list "sts" "StatefulSet" -}}
+{{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (has .Values.persistence.type $sts)))}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "docker-registry.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
@@ -15,6 +21,7 @@ spec:
       app: {{ template "docker-registry.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.replicaCount }}
+  serviceName: {{ .Values.service.name }}
   {{- if .Values.updateStrategy }}
   strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
@@ -94,4 +101,29 @@ spec:
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       volumes: {{ include "docker-registry.volumes" . | nindent 8 }}
+  {{- if .Values.persistence.enabled}}
+  volumeClaimTemplates:
+  - metadata:
+      # This should match the name defined in the file _helpers.tpl when the 
+      # condition (if eq .Values.storage "filesystem") is met.
+      name: data
+      namespace: {{ .Values.namespace | default .Release.Namespace }}
+      labels:
+        app: {{ template "docker-registry.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      accessModes:
+        - {{ .Values.persistence.accessMode | quote }}
+      storageClassName: {{ .Values.persistence.storageClass }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+      {{- with .Values.persistence.selectorLabels }}
+      selector:
+        matchLabels:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -63,10 +63,14 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 persistence:
+  # Persistence can be achieved either with a PVC or StatefulSet. Default to PVC.
+  type: pvc
   accessMode: 'ReadWriteOnce'
   enabled: false
   size: 10Gi
   # storageClass: '-'
+  ## Name of an existing PVC. Can be templated.
+  # existingClaim:
 
 # set the type of filesystem to use: filesystem, s3
 storage: filesystem
@@ -224,3 +228,6 @@ garbageCollect:
   enabled: false
   deleteUntagged: true
   schedule: "0 1 * * *"
+
+# Use StatefulSet instead of Deployment. Default uses Deployment.
+useStatefulSet: false


### PR DESCRIPTION
Adding support for `StatefuleSet` on v2.2.2.

## Source of inspiration

The [grafana helm chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana) supports both StatefuleSet and Deployment.

## Release Notes

Adding support for deploying the container registry using a Kubernetes `StatefuleSet` manifest object with dedicated per-sts PVC. Compatible with podAntiAffinity.