### PR TITLE
Migrate PodDisruptionBudget policy/v1beta1 to policy/v1

### DIFF
--- a/templates/poddisruptionbudget.yaml
+++ b/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "docker-registry.fullname" . }}


### PR DESCRIPTION
In k8s 1.25 policy/v1beta1 is no longer served, migrate to policy/v1.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25