### PR TITLE
feat: Adding support for extraContainers and StatefuleSet deployment on v2.2.2

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -187,7 +187,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
       path: htpasswd
 {{- end }}
 
-{{- if eq .Values.storage "filesystem" }}
+{{- if (and (eq .Values.storage "filesystem") (not .Values.useStatefulSet)) }}
 - name: data
   {{- if .Values.persistence.enabled }}
   persistentVolumeClaim:

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.persistence.enabled }}
-{{- if not .Values.persistence.existingClaim -}}
+{{- if (not .Values.useStatefulSet) }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "pvc")}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -24,4 +24,4 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end -}}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -1,6 +1,7 @@
-{{- if (and (not .Values.useStatefulSet) (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc"))) }}
+{{- $sts := list "sts" "StatefulSet" -}}
+{{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (has .Values.persistence.type $sts)))}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "docker-registry.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
@@ -15,6 +16,7 @@ spec:
       app: {{ template "docker-registry.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.replicaCount }}
+  serviceName: {{ .Values.service.name }}
   {{- if .Values.updateStrategy }}
   strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
@@ -97,4 +99,29 @@ spec:
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       volumes: {{ include "docker-registry.volumes" . | nindent 8 }}
+  {{- if .Values.persistence.enabled}}
+  volumeClaimTemplates:
+  - metadata:
+      # This should match the name defined in the file _helpers.tpl when the 
+      # condition (if eq .Values.storage "filesystem") is met.
+      name: data
+      namespace: {{ .Values.namespace | default .Release.Namespace }}
+      labels:
+        app: {{ template "docker-registry.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      accessModes:
+        - {{ .Values.persistence.accessMode | quote }}
+      storageClassName: {{ .Values.persistence.storageClass }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+      {{- with .Values.persistence.selectorLabels }}
+      selector:
+        matchLabels:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -63,10 +63,14 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 persistence:
+  # Persistence can be achieved either with a PVC or StatefulSet. Default to PVC.
+  type: pvc
   accessMode: 'ReadWriteOnce'
   enabled: false
   size: 10Gi
   # storageClass: '-'
+  ## Name of an existing PVC. Can be templated.
+  # existingClaim:
 
 # set the type of filesystem to use: filesystem, s3
 storage: filesystem
@@ -220,7 +224,13 @@ initContainers: []
 #   image: busybox
 #   command: []
 
+extraContainers: []
+# Additional containers to be added
+
 garbageCollect:
   enabled: false
   deleteUntagged: true
   schedule: "0 1 * * *"
+
+# Use StatefulSet instead of Deployment. Default uses Deployment.
+useStatefulSet: false


### PR DESCRIPTION
This cancels and replace a previous [PR 87](https://github.com/twuni/docker-registry.helm/pull/87).

The purpose of these modifications is to add support for deploying the registry container as a `StatefuleSet` STS instead of a `Deployment`. This need several modifications on the templates, because the STS handles volume differently than the `Deployment`. A source of inspiration for this modification is the Grafana Helm Chart https://github.com/grafana/helm-charts/tree/main/charts/grafana.

And also adding support for `extraContainers` to be able to add sidecar containers to the registry container to support calling OCI syncing tools like [dregsy](https://github.com/xelalexv/dregsy) or [skopeo](https://github.com/containers/skopeo) to populate the OCI registry.

```yaml
# values.yaml for the `twuni/docker-registry.helm` helm chart
[...]
#extraContainers: []
# Additional containers to be added
extraContainers:
  ## Side car container for registry synchronization with dregsy and skopeo
  - name: dregsy
    image: docker.io/xelalex/dregsy
    imagePullPolicy: IfNotPresent
    command: ['dregsy', '-config=/home/dregsy/config/dregsy-config.yaml']
    resources:
      requests:
        cpu: 10m
        memory: 32Mi
    securityContext:
      allowPrivilegeEscalation: false
      privileged: false
      runAsNonRoot: true
      capabilities:
        drop:
        - all
    volumeMounts:
      - name: dregsy-config
        mountPath: /home/dregsy/config/
        readOnly: true
[...]
```

Signed-off-by: Nicolas-Peiffer <102670102+Nicolas-Peiffer@users.noreply.github.com>

## Release Notes

* Adding support for deploying the container registry using a Kubernetes `StatefuleSet` manifest object with dedicated per-sts PVC. Compatible with `podAntiAffinity`.
* Adding support for `extraContainers` to support calling OCI syncing tools like [dregsy](https://github.com/xelalexv/dregsy) or [skopeo](https://github.com/containers/skopeo) to populate the OCI registry.