### PR TITLE
feat: allow conditional secret creation

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.secrets.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -38,3 +39,4 @@ data:
   {{- end }}
   proxyUsername: {{ .Values.proxy.username | default "" | b64enc | quote }}
   proxyPassword: {{ .Values.proxy.password | default "" | b64enc | quote }}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -74,6 +74,7 @@ storage: filesystem
 # Set this to name of secret for tls certs
 # tlsSecretName: registry.docker.example.com
 secrets:
+  create: true
   haSharedSecret: ""
   htpasswd: ""
 # Secrets for Azure


### PR DESCRIPTION
My usecase is gitops and I need to be able to create secrets with sealed-secrets or vault.

This PR does not change default behavior in any way but gives an additional switch to not create the secret.

I will most likely followup with another PR to allow dynamic secret configuration.

cheers
