### PR TITLE
fix: allow to set emptyDir sizeLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ their default values.
 | `autoscaling.behavior`      | (Kubernetes ≥1.23) Configurable scaling behavior                                           | `{}`            |
 | `priorityClassName      `   | priorityClassName                                                                          | `""`            |
 | `storage`                   | Storage system to use                                                                      | `filesystem`    |
+| `emptydir.size`             | Amount of space to claim for emptyDir ephemeral storage                                    | `0`             |
 | `tlsSecretName`             | Name of secret for TLS certs                                                               | `nil`           |
 | `secrets.htpasswd`          | Htpasswd authentication                                                                    | `nil`           |
 | `secrets.s3.accessKey`      | Access Key for S3 configuration                                                            | `nil`           |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -193,7 +193,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   persistentVolumeClaim:
     claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "docker-registry.fullname" . }}{{- end }}
   {{- else }}
-  emptyDir: {}
+  emptyDir:
+    sizeLimit: {{ .Values.emptydir.size }}
   {{- end -}}
 {{- end }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -71,6 +71,10 @@ persistence:
 # set the type of filesystem to use: filesystem, s3
 storage: filesystem
 
+# set sizeLimit for emptyDir. Default is unlimited
+emptydir:
+  size: "0"
+
 # Set this to name of secret for tls certs
 # tlsSecretName: registry.docker.example.com
 secrets:


### PR DESCRIPTION
This PR allows setting ephemeral storage sizeLimit.

Right now if no PVC storage is defined, an emptyDir volume is created without any size limits. This can cause the storage of the node to run out.

This PR adds an option to limit ephemeral storage the same way as we limit PVC claim storage.

https://kubernetes.io/docs/concepts/storage/volumes/#emptydir

Default value is set to "0" - which is unlimited