### PR TITLE
docs: Document that `s3.regionEndpoint` requires a transport scheme

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -97,7 +97,7 @@ secrets:
 # Options for s3 storage type:
 # s3:
 #  region: us-east-1
-#  regionEndpoint: s3.us-east-1.amazonaws.com
+#  regionEndpoint: https://s3.us-east-1.amazonaws.com
 #  bucket: my-bucket
 #  rootdirectory: /object/prefix
 #  encrypt: false


### PR DESCRIPTION
The `regionEndpoint` value does not work at all without one, so provide a nice hint that it is required in the vendor-provided materials.

Fixes Issue: #97