### PR TITLE
Add sidecars support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ their default values.
 | `extraVolumes`              | Additional volumes to the pod                                                              | `[]`            |
 | `extraEnvVars`              | Additional environment variables to the pod                                                | `[]`            |
 | `initContainers`            | Init containers to be created in the pod                                                   | `[]`            |
+| `sidecars`            | Sidecar containers to be created in the pod                                                   | `[]`            |
 | `garbageCollect.enabled`    | If true, will deploy garbage-collector cronjob                                             | `false`         |
 | `garbageCollect.deleteUntagged` | If true, garbage-collector will delete manifests that are not currently referenced via tag | `true` |    |
 | `garbageCollect.schedule`   | CronTab schedule, please use standard crontab format                                        | `0 1 * * *` |  |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
+        {{- with .Values.sidecars }}
+          {{- toYaml .Values.sidecars | nindent 8 }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/values.yaml
+++ b/values.yaml
@@ -220,6 +220,12 @@ initContainers: []
 #   image: busybox
 #   command: []
 
+sidecars: []
+## Sidecar containers to add to the Deployment
+# - name: init
+#   image: busybox
+#   command: []
+
 garbageCollect:
   enabled: false
   deleteUntagged: true


### PR DESCRIPTION
Add the ability to specify sidecar containers.
The motivation on this change is because I need to implement a whitelist for the registry (in proxy mode) and as the registry image does not support a whitelist configuration, the alternative is running a reverse proxy in the pod to reject the non-whitelisted images
The reverse proxy could run in other pod, however, allowing sidecars to be set will help whoever needs it.
Hope it helps!