### PR TITLE
Add missing fields for Security context  and secrets

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -38,9 +38,7 @@ spec:
           priorityClassName: "{{ .Values.priorityClassName }}"
           {{- end }}
           {{- if .Values.securityContext.enabled }}
-          securityContext:
-            fsGroup: {{ .Values.securityContext.fsGroup }}
-            runAsUser: {{ .Values.securityContext.runAsUser }}
+          securityContext: {{ omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           containers:
             - name: {{ .Chart.Name }}
@@ -52,6 +50,9 @@ spec:
               - --delete-untagged={{ .Values.garbageCollect.deleteUntagged }}
               - /etc/docker/registry/config.yml
               env: {{ include "docker-registry.envs" . | nindent 16 }}
+              {{- if .Values.containerSecurityContext.enabled }}
+              securityContext: {{ omit .Values.containerSecurityContext "enabled" | toYaml | nindent 16 }}
+              {{- end }}
               volumeMounts: {{ include "docker-registry.volumeMounts" . | nindent 16 }}
           restartPolicy: OnFailure
           {{- if .Values.nodeSelector }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -43,9 +43,7 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       {{- if .Values.securityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+      securityContext: {{ omit .Values.securityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
@@ -82,6 +80,9 @@ spec:
               port: 5000
           resources: {{ toYaml .Values.resources | nindent 12 }}
           env: {{ include "docker-registry.envs" . | nindent 12 }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{ omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts: {{ include "docker-registry.volumeMounts" . | nindent 12 }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -152,6 +152,9 @@ configData:
       interval: 10s
       threshold: 3
 
+containerSecurityContext:
+  enabled: false
+
 securityContext:
   enabled: true
   runAsUser: 1000


### PR DESCRIPTION
Due to PodSecurity policies in place after CIS hardening my cluster, I had to add the following to the pod or container security context:
```
runAsNonRoot: true
seccompProfile:
  type: "RuntimeDefault"
allowPrivilegeEscalation: false
capabilities:
  drop:
  - ALL
```
With the current securityContext implementation, only `securityContext.fsGroup` and `securityContext.runAsUser` were included. This change adds the ability to include everything in the `securityContext` provided. It also removes the `enabled` parameter which is unnecessary to me because we can just check if anything in the `securityContext` exists.

I added a `containerSecurityContext` to help differentiate between adding these fields for a container or the service itself. If `securityContext` is added for the service, PodSecurity fails because it specifically asks to be added to the container level.

This also adds a missing field for secrets called `secretRef` for s3.