### PR TITLE
Disable blob caching when garbage-collection is enabled

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- /* Blob caching and the garbage-collection cronjob do not mix */ -}}
+{{- if .Values.garbageCollect.enabled -}}
+{{- $_ := set .Values.configData.storage.cache "blobdescriptor" "disabled" -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
The garbage-collection cronjob will cause the registry to go into an inconsistent state if the blob cache is not cleared afterward.

Since the cronjob has no facility for doing that, disable blob caching entirely when garbage-collection is in use.

Fixes: Issue #104