### PR TITLE
Better control over metrics port in SVC

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -38,7 +38,7 @@ spec:
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
 {{- end }}
-{{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
     - port: {{ .Values.metrics.port }}
       protocol: TCP
       name: http-metrics


### PR DESCRIPTION
I am doing a PoC for running multiple docker registry mirrors on SVC of LB type using this helm chart. During this I run into an issue where registry metrics were available on LB port, which isn't ideal. Since metrics port is required only when ServiceMonitor is enabled it might make more sense to use `.Values.metrics.serviceMonitor.enabled` for this instead of `.Values.metrics.enabled`.

Ideally though it would be beneficial to use a PodMonitor instead and not expose this port on SVC at all. However since this would require a bit more changes I am including it in a separate PR available here - https://github.com/twuni/docker-registry.helm/pull/108. If you decide one of those PRs is appropriate, please close the other one (or both :) )