### PR TITLE
Support for setting the service name

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
   name: {{ template "docker-registry.fullname" . }}
+{{- end }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     app: {{ template "docker-registry.name" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ image:
 # imagePullSecrets:
     # - name: docker
 service:
-  name: registry
+  name: "" 
   type: ClusterIP
   # sessionAffinity: None
   # sessionAffinityConfig: {}


### PR DESCRIPTION
### Problem

It would be useful to be able to specify the service name and not rely on the `fullname` (which requires using `fullnameOverride` to set).

While `service.name` is defined in the `values.yaml`, it is not referenced anywhere. 

### Proposed Solution

- Set the default value of `service.name` to `""` and add an `if/else` conditional in the service template that will allow you to specify the service name.
- If unset, it will fallback to the existing behavior.