### PR TITLE
Update README.md to use correct default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ their default values.
 |:----------------------------|:-------------------------------------------------------------------------------------------|:----------------|
 | `image.pullPolicy`          | Container pull policy                                                                      | `IfNotPresent`  |
 | `image.repository`          | Container image to use                                                                     | `registry`      |
-| `image.tag`                 | Container image tag to deploy                                                              | `2.7.1`         |
+| `image.tag`                 | Container image tag to deploy                                                              | `2.8.1`         |
 | `imagePullSecrets`          | Specify image pull secrets                                                                 | `nil` (does not add image pull secrets to deployed pods) |
 | `persistence.accessMode`    | Access mode to use for PVC                                                                 | `ReadWriteOnce` |
 | `persistence.enabled`       | Whether to use a PVC for the Docker storage                                                | `false`         |


### PR DESCRIPTION
The default tag has been 2.8.1 since the last release at the very least: https://github.com/twuni/docker-registry.helm/blob/v2.2.2/values.yaml#L22