### PR TITLE
🔑 add publisher verification for artifact hub

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: cd3641a7-55ab-436a-b7d1-58c398969d59
+owners:
+- email: devin@canterberry.cc
+  name: Devin Canterberry


### PR DESCRIPTION
Summary
-------

Artifact Hub supports a simple cross-reference mechanism for verifying a Helm chart's publisher. This changeset implements that, resulting in a "verified publisher" checkmark on this chart's listing on Artifact Hub.

Resources
---------

This chart is located on Artifact Hub at https://artifacthub.io/packages/helm/twuni/docker-registry.

More information about publisher verification at https://artifacthub.io/docs/topics/repositories/#verified-publisher

An **artifacthub-repo.yml** template is available at https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml

Note
----

I only included myself in the list of `owners`. Maintainers, please feel free to add yourselves here and elsewhere as you see fit. 