### PR TITLE
chore: add helm release action

### DIFF
--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,9 +1,7 @@
 name: Release Charts
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,0 +1,37 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      
+      - name: Install chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          install_only: true
+
+      - name: Run chart-releaser
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+        run: |
+          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          cr package
+          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
+          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.cr-release-packages


### PR DESCRIPTION
The chart-releaser-action requires that helm charts be placed into chart/<chart_name> to work. I've tried configuring it appropriately for this repo, but couldn't get it to work.

Instead, I'm using that action to install just the chart-releaser binary. Then, I'm using the `cr` binary to package, release, and update the index in the gh-pages branch.

Any commit on the main branch will cause a new release as long as the chart version has changed.