### PR TITLE
add the ability to specify labels for the registry service

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -37,6 +37,8 @@ service:
   # loadBalancerSourceRanges:
   annotations: {}
   # foo.io/bar: "true"
+  labels: {}
+  # foo.io/baz: "false"
 ingress:
   enabled: false
   className: nginx


### PR DESCRIPTION
Labels can currently be specified for the ingress, servicemonitor, prometheusRules, and the registry pods themselves.

This expands that to the registry service, so that we can exclude it from velero snapshots and restores. (why? because we create this with a static IP address, and velero does not restore static IP addresses)

I would also be happy to expand this pattern to all of the other resources in the repository - the configmap, cronjob, deployment, hpa, pdb, pvc, secret and serviceaccount objects.