### PR TITLE
[TINY] Fix copy command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ This chart will do the following:
 First, add the repo:
 
 ```console
-$ helm repo add twuni https://helm.twun.io
+helm repo add twuni https://helm.twun.io
 ```
 
 To install the chart, use the following:
 
 ```console
-$ helm install twuni/docker-registry
+helm install twuni/docker-registry
 ```
 
 ## Configuration


### PR DESCRIPTION
Removed the $ sign to allow users to take advantage of the handy copy snippet functionality offered by the GitHub UI