### PR TITLE
Allow for setting annotations on persistentvolumeclaim via persistence.annotations

### DIFF
--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -10,6 +10,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if (.Values.persistence).annotations }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}


### PR DESCRIPTION
This allows for providing annotations that are scoped to the persistentvolumeclaim associated with the chart.  If not provided, it should be backwards compatible (no difference in behavior).