### PR TITLE
Add volumename support to pvc

### DIFF
--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -16,12 +16,12 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-{{- if .Values.persistence.storageClass }}
-{{- if (eq "-" .Values.persistence.storageClass) }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""
-{{- else }}
+  {{- else }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
-{{- end }}
-{{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end -}}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -23,5 +23,8 @@ spec:
   storageClassName: "{{ .Values.persistence.storageClass }}"
   {{- end }}
   {{- end }}
+  {{- if .Values.persistence.volumeName }}
+  volumeName: {{ .Values.persistence.volumeName | quote }}
+  {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
With this parameter, you can force bind to a named persistent volume.