### PR TITLE
Security improvements for Pod Security Standard restricted support and do not mount service account tokens

### DIFF
--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -10,6 +10,7 @@ jobs:
   release:
     permissions:
       contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -49,5 +49,4 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.repository_owner }} --password-stdin
           helm package ${{ github.workspace }}/
           package=`ls -t docker-registry-*.tgz | head -n 1`
-          echo "helm push ${package} oci://${{ env.GCR_IMAGE }}"
           helm push "${package}" oci://${{ env.GCR_IMAGE }}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -51,4 +51,5 @@ jobs:
         run: |
            helm package ${{ github.workspace }}/
            package=`ls -t docker-registry-*.tgz | head -n 1`
-           helm push "${package}" ${{ env.GCR_IMAGE }}:{{ .Version }}
+           echo "helm push ${package} oci://${{ env.GCR_IMAGE }}:{{ .Version }}"
+           helm push "${package}" oci://${{ env.GCR_IMAGE }}:{{ .Version }}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,7 +1,7 @@
 name: Release Charts
 env:
   HELM_VERSION_TO_INSTALL: 3.14.0
-  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/doker-registry
+  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/docker-registry
   
 on:
   workflow_dispatch:
@@ -46,6 +46,7 @@ jobs:
       - name: login to acr using helm
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.GCR_IMAGE }} --username ${{ github.repository_owner }} --password-stdin
+          
       - name: save helm chart to local registry
         run: |
            helm package ${{ github.workspace }}/
@@ -53,4 +54,4 @@ jobs:
 
       - name: publish chart to acr
         run: |
-            helm chart push ${{ env.GCR_IMAGE }}:${{ github.sha }}
+            helm push dockery-registry-{{ .Version }}.tgz ${{ env.GCR_IMAGE }}:${{ .Version }}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -50,8 +50,5 @@ jobs:
       - name: save helm chart to local registry
         run: |
            helm package ${{ github.workspace }}/
-           ls
-
-      - name: publish chart to acr
-        run: |
-            helm push dockery-registry-{{ .Version }}.tgz ${{ env.GCR_IMAGE }}:${{ .Version }}
+           package=`ls -t docker-registry-*.tgz | head -n 1`
+           helm push "${package}" ${{ env.GCR_IMAGE }}:{{ .Version }}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -48,7 +48,8 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.GCR_IMAGE }} --username ${{ github.repository_owner }} --password-stdin
       - name: save helm chart to local registry
         run: |
-           helm chart save ${{ github.workspace }}/ ${{ env.GCR_IMAGE }}:${{ github.sha }}
+           helm package ${{ github.workspace }}/
+           ls
 
       - name: publish chart to acr
         run: |

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -51,5 +51,6 @@ jobs:
         run: |
            helm package ${{ github.workspace }}/
            package=`ls -t docker-registry-*.tgz | head -n 1`
-           echo "helm push ${package} oci://${{ env.GCR_IMAGE }}:{{ .Version }}"
-           helm push "${package}" oci://${{ env.GCR_IMAGE }}:{{ .Version }}
+           version=`echo "${package}"| sed "s|docker-registry-\(.*\)[.]tgz|\1|g"`
+           echo "helm push ${package} oci://${{ env.GCR_IMAGE }}:${version}"
+           helm push "${package}" oci://${{ env.GCR_IMAGE }}:${version}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -28,18 +28,18 @@ jobs:
         with:
           install_only: true
 
-      - name: Run chart-releaser
-        env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
-        run: |
-          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
-          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
-          cr package
-          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
-          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."
+#      - name: Run chart-releaser
+#        env:
+#          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+#        run: |
+#          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+#          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+#          cr package
+#          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
+#          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."
 
       - name: install helm
-        uses: Azure/setup-helm@v1
+        uses: Azure/setup-helm@v4.2.0
         with:
           # Version of helm
           version: ${{ env.HELM_VERSION_TO_INSTALL }} # default is latest

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -51,6 +51,5 @@ jobs:
         run: |
            helm package ${{ github.workspace }}/
            package=`ls -t docker-registry-*.tgz | head -n 1`
-           version=`echo "${package}"| sed "s|docker-registry-\(.*\)[.]tgz|\1|g"`
-           echo "helm push ${package} oci://${{ env.GCR_IMAGE }}:${version}"
-           helm push "${package}" oci://${{ env.GCR_IMAGE }}:${version}
+           echo "helm push ${package} oci://${{ env.GCR_IMAGE }}"
+           helm push "${package}" oci://${{ env.GCR_IMAGE }}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,7 +1,7 @@
 name: Release Charts
 env:
   HELM_VERSION_TO_INSTALL: 3.14.0
-  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/charts
+  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}
   
 on:
   workflow_dispatch:
@@ -48,5 +48,5 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.GCR_IMAGE }} --username ${{ github.repository_owner }} --password-stdin
           helm package ${{ github.workspace }}/
           package=`ls -t docker-registry-*.tgz | head -n 1`
-          echo "helm push ${package} oci://${{ env.GCR_IMAGE }}"
-          helm push "${package}" oci://${{ env.GCR_IMAGE }}
+          echo "helm push ${package} oci://${{ env.GCR_IMAGE }}/charts"
+          helm push "${package}" oci://${{ env.GCR_IMAGE }}/charts

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -28,16 +28,16 @@ jobs:
         with:
           install_only: true
 
-#      - name: Run chart-releaser
-#        env:
-#          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
-#        run: |
-#          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
-#          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
-#          cr package
-#          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
-#          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."
-#
+      - name: Run chart-releaser
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+        run: |
+          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          cr package
+          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
+          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."
+
       - name: install helm
         uses: Azure/setup-helm@v1
         with:

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -43,13 +43,10 @@ jobs:
           # Version of helm
           version: ${{ env.HELM_VERSION_TO_INSTALL }} # default is latest
 
-      - name: login to acr using helm
+      - name: publish to oci registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.GCR_IMAGE }} --username ${{ github.repository_owner }} --password-stdin
-          
-      - name: save helm chart to local registry
-        run: |
-           helm package ${{ github.workspace }}/
-           package=`ls -t docker-registry-*.tgz | head -n 1`
-           echo "helm push ${package} oci://${{ env.GCR_IMAGE }}"
-           helm push "${package}" oci://${{ env.GCR_IMAGE }}
+          helm package ${{ github.workspace }}/
+          package=`ls -t docker-registry-*.tgz | head -n 1`
+          echo "helm push ${package} oci://${{ env.GCR_IMAGE }}"
+          helm push "${package}" oci://${{ env.GCR_IMAGE }}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -27,16 +27,16 @@ jobs:
         with:
           install_only: true
 
-      - name: Run chart-releaser
-        env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
-        run: |
-          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
-          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
-          cr package
-          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
-          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."
-
+#      - name: Run chart-releaser
+#        env:
+#          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+#        run: |
+#          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+#          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+#          cr package
+#          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
+#          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."
+#
       - name: install helm
         uses: Azure/setup-helm@v1
         with:

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,7 +1,7 @@
 name: Release Charts
 env:
   HELM_VERSION_TO_INSTALL: 3.14.0
-  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/docker-registry
+  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/charts
   
 on:
   workflow_dispatch:

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -45,8 +45,8 @@ jobs:
 
       - name: publish to oci registry
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.GCR_IMAGE }} --username ${{ github.repository_owner }} --password-stdin
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.repository_owner }} --password-stdin
           helm package ${{ github.workspace }}/
           package=`ls -t docker-registry-*.tgz | head -n 1`
-          echo "helm push ${package} oci://${{ env.GCR_IMAGE }}/charts"
-          helm push "${package}" oci://${{ env.GCR_IMAGE }}/charts
+          echo "helm push ${package} oci://${{ env.GCR_IMAGE }}"
+          helm push "${package}" oci://${{ env.GCR_IMAGE }}

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -28,15 +28,15 @@ jobs:
         with:
           install_only: true
 
-#      - name: Run chart-releaser
-#        env:
-#          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
-#        run: |
-#          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
-#          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
-#          cr package
-#          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
-#          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."
+      - name: Run chart-releaser
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+        run: |
+          owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+          repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+          cr package
+          cr upload --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --skip-existing --generate-release-notes --commit main
+          cr index --owner="$owner" --git-repo "$repo" --token="$CR_TOKEN" --release-name-template="v{{ .Version }}" --packages-with-index --push --index-path="."
 
       - name: install helm
         uses: Azure/setup-helm@v4.2.0

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
       {{- if or (eq .Values.serviceAccount.create true) (ne .Values.serviceAccount.name "") }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "docker-registry.fullname" .) }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   labels:
     app: {{ template "docker-registry.name" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -12,10 +12,13 @@ updateStrategy: {}
 podAnnotations: {}
 podLabels: {}
 
+automountServiceAccountToken: false
+
 serviceAccount:
   create: false
   name: ""
   annotations: {}
+  automountServiceAccountToken: false
 
 image:
   repository: registry
@@ -177,6 +180,8 @@ securityContext:
   sysctls: []
   supplementalGroups: []
   fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 priorityClassName: ""
 


### PR DESCRIPTION
In support of running the Docker Registry in a namespace where Pod Security Standard restricted profile is in use and Istio is injecting a sidecar, the seccompProfile needs to be constrained. This change to values.yaml has no effect if Istio is not being used.

Also, to address best practices for securing a Helm chart, the mounting of service account tokens should not be performed unless it is needed.  Since this application does not appear to use it, it can be disabled (value of false).   Removing it in both the service account and the deployment (pod) definition is the recommended security guideline.