### PR TITLE
feat: configure cronjob restartPolicy through values

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -68,7 +68,7 @@ spec:
               securityContext: {{ omit .Values.containerSecurityContext "enabled" | toYaml | nindent 16 }}
               {{- end }}
               volumeMounts: {{ include "docker-registry.volumeMounts" . | nindent 16 }}
-          restartPolicy: OnFailure
+          restartPolicy: {{ .Values.garbageCollect.restartPolicy }}
           {{- if .Values.nodeSelector }}
           nodeSelector: {{ toYaml .Values.nodeSelector | nindent 12 }}
           {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -249,6 +249,7 @@ garbageCollect:
   enabled: false
   deleteUntagged: true
   schedule: "0 1 * * *"
+  restartPolicy: OnFailure
   podAnnotations: {}
   podLabels: {}
   resources: {}


### PR DESCRIPTION
Currently this setting is hard-coded in CronJob template.

Default value is the same as hard-coded value in order to avoid breaking changes.