### PR TITLE
Update garbageCollect cronjob

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -31,11 +31,11 @@ spec:
           labels:
             release: {{ .Release.Name }}
             {{- if or .Values.podLabels .Values.garbageCollect.podLabels }}
-            {{- toYaml (merge (.Values.podLabels | default (dict)) (.Values.garbageCollect.podLabels | default (dict))) | nindent 12 }}
+            {{- toYaml (merge (.Values.garbageCollect.podLabels | default (dict)) (.Values.podLabels | default (dict))) | nindent 12 }}
             {{- end }}
           {{- if or .Values.podAnnotations .Values.garbageCollect.podAnnotations }}
           annotations:
-            {{- toYaml (merge (.Values.podAnnotations | default (dict)) (.Values.garbageCollect.podAnnotations | default (dict))) | nindent 12 }}
+            {{- toYaml (merge (.Values.garbageCollect.podAnnotations | default (dict)) (.Values.podAnnotations | default (dict))) | nindent 12 }}
           {{- end}}
         spec:
           {{- if or (eq .Values.serviceAccount.create true) (ne .Values.serviceAccount.name "") }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -30,27 +30,13 @@ spec:
         metadata:
           labels:
             release: {{ .Release.Name }}
-            {{- if .Values.garbageCollect.podLabels }}
-            {{- with .Values.garbageCollect.podLabels }}
-            {{- toYaml . | nindent 12 }}
+            {{- if or .Values.podLabels .Values.garbageCollect.podLabels }}
+            {{- toYaml (merge (.Values.podLabels | default (dict)) (.Values.garbageCollect.podLabels | default (dict))) | nindent 12 }}
             {{- end }}
-            {{- else if .Values.podLabels }}
-            {{- with .Values.podLabels }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- end }}
+          {{- if or .Values.podAnnotations .Values.garbageCollect.podAnnotations }}
           annotations:
-            checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-            checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-            {{- if .Values.garbageCollect.podAnnotations }}
-            {{- with .Values.garbageCollect.podAnnotations }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- else if .Values.podAnnotations }}
-            {{- with .Values.podAnnotations}}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- end }}
+            {{- toYaml (merge (.Values.podAnnotations | default (dict)) (.Values.garbageCollect.podAnnotations | default (dict))) | nindent 12 }}
+          {{- end}}
         spec:
           {{- if or (eq .Values.serviceAccount.create true) (ne .Values.serviceAccount.name "") }}
           serviceAccountName: {{ .Values.serviceAccount.name | default (include "docker-registry.fullname" .) }}
@@ -73,7 +59,10 @@ spec:
               - garbage-collect
               - --delete-untagged={{ .Values.garbageCollect.deleteUntagged }}
               - /etc/docker/registry/config.yml
-              resources: {{ toYaml .Values.garbageCollect.resources | nindent 16 }}
+              {{- if .Values.garbageCollect.resources }}
+              resources:
+              {{- toYaml .Values.garbageCollect.resources | nindent 16 }}
+              {{- end }}
               env: {{ include "docker-registry.envs" . | nindent 16 }}
               {{- if .Values.containerSecurityContext.enabled }}
               securityContext: {{ omit .Values.containerSecurityContext "enabled" | toYaml | nindent 16 }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -17,16 +17,40 @@ spec:
         app: {{ template "docker-registry.name" . }}
         release: {{ .Release.Name }}
         {{- with .Values.podLabels }}
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
-        {{ toYaml .Values.podAnnotations | nindent 8 }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       template:
+        metadata:
+          labels:
+            release: {{ .Release.Name }}
+            {{- if .Values.garbageCollect.podLabels }}
+            {{- with .Values.garbageCollect.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- else if .Values.podLabels }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- end }}
+          annotations:
+            checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+            checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+            {{- if .Values.garbageCollect.podAnnotations }}
+            {{- with .Values.garbageCollect.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- else if .Values.podAnnotations }}
+            {{- with .Values.podAnnotations}}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- end }}
         spec:
           {{- if or (eq .Values.serviceAccount.create true) (ne .Values.serviceAccount.name "") }}
           serviceAccountName: {{ .Values.serviceAccount.name | default (include "docker-registry.fullname" .) }}
@@ -49,7 +73,7 @@ spec:
               - garbage-collect
               - --delete-untagged={{ .Values.garbageCollect.deleteUntagged }}
               - /etc/docker/registry/config.yml
-              resources: {{ toYaml .Values.garbageCollect.resources | nindent 12 }}
+              resources: {{ toYaml .Values.garbageCollect.resources | nindent 16 }}
               env: {{ include "docker-registry.envs" . | nindent 16 }}
               {{- if .Values.containerSecurityContext.enabled }}
               securityContext: {{ omit .Values.containerSecurityContext "enabled" | toYaml | nindent 16 }}

--- a/values.yaml
+++ b/values.yaml
@@ -61,11 +61,11 @@ resources: {}
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 100m
+  #   memory: 128Mi
   # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 100m
+  #   memory: 128Mi
 persistence:
   accessMode: 'ReadWriteOnce'
   enabled: false
@@ -98,17 +98,17 @@ secrets:
 
 # Options for s3 storage type:
 # s3:
-#  region: us-east-1
-#  regionEndpoint: https://s3.us-east-1.amazonaws.com
-#  bucket: my-bucket
-#  rootdirectory: /object/prefix
-#  encrypt: false
-#  secure: true
+#   region: us-east-1
+#   regionEndpoint: https://s3.us-east-1.amazonaws.com
+#   bucket: my-bucket
+#   rootdirectory: /object/prefix
+#   encrypt: false
+#   secure: true
 
 # Options for swift storage type:
 # swift:
-#  authurl: http://swift.example.com/
-#  container: my-container
+#   authurl: http://swift.example.com/
+#   container: my-container
 
 # https://docs.docker.com/registry/recipes/mirror/
 proxy:
@@ -245,4 +245,16 @@ garbageCollect:
   enabled: false
   deleteUntagged: true
   schedule: "0 1 * * *"
+  podAnnotations: {}
+  podLabels: {}
   resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi


### PR DESCRIPTION
This change will provide `podLabels` and `podAnnotations` options specific to the `garbageCollect` cronjob job pod with defaults to the root `podLabels` and `podAnnotations`. There are a few minor fixes for yaml rendering for the cronjob as well where spaces were left in the cronjob yaml. There are `podLabels` and `podAnnotations` options added in the `values.yaml` file and some minor spacing fixes in that file as well.

I used the [merge function](https://helm.sh/docs/chart_template_guide/function_list/#merge-mustmerge) in Helm along with [default](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function) and an empty [`dict`](https://helm.sh/docs/chart_template_guide/function_list/#dict) (dictionary). The logic and functions should prefer the `garbageCollect.podLabels/podAnnotations` values over the root `podLabels/podAnnotations` and if neither are provided should output an empty map.