### PR TITLE
🏁 v2.3.0 Release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 2.2.3
+version: 2.3.0
 appVersion: 2.8.1
 home: https://hub.docker.com/_/registry/
 icon: https://helm.twun.io/docker-registry.png


### PR DESCRIPTION
The most substantive change between 2.2.3 and 2.3.0 is setting `containerSecurityContext: true` by default. 

The pod was previously configured, via PodSecurityContext, to run as non-root user 1000. The additional container security context sets the container to also run as group 1000, drop all capabilities, and set a few other security settings. It looks to be using the [restricted pod security standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted). The change's associated PR is [here](https://github.com/twuni/docker-registry.helm/pull/129).

Locally, using Orbstack, I am able to pull and push from the registry using this minimal config:

```yaml
ingress:
  enabled: true
  hosts:
    - registry.k8s.orb.local

persistence:
  enabled: true
```

Full change set is viewable here: https://github.com/twuni/docker-registry.helm/compare/v2.2.3...main

- Use restricted pod security standard by default (by setting `containerSecurityContext: true` by default)
- Updates to README
- Ability to set labels on service
- Ability to set labels and annotations on CronJob
- Ability to set resources on CronJob