### PR TITLE
Update README.md for garbageCollect

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ their default values.
 | `service.sessionAffinityConfig` | service session affinity config                                                        | `nil`           |
 | `replicaCount`              | k8s replicas                                                                               | `1`             |
 | `updateStrategy`            | update strategy for deployment                                                             | `{}`            |
-| `podAnnotations`            | Annotations for pod                                                                        | `{}`            |
-| `podLabels`                 | Labels for pod                                                                             | `{}`            |
+| `podAnnotations`            | Annotations for deployment pod, and `garbageCollect` pod unless set explicitly there. See `garbageCollect` | `{}` |
+| `podLabels`                 | Labels for deployment pod, and `garbageCollect` pod unless set explicitly there. See `garbageCollect` | `{}` |
 | `podDisruptionBudget`       | Pod disruption budget                                                                      | `{}`            |
 | `resources.limits.cpu`      | Container requested CPU                                                                    | `nil`           |
 | `resources.limits.memory`   | Container requested memory                                                                 | `nil`           |
@@ -119,6 +119,8 @@ their default values.
 | `garbageCollect.enabled`    | If true, will deploy garbage-collector cronjob                                             | `false`         |
 | `garbageCollect.deleteUntagged` | If true, garbage-collector will delete manifests that are not currently referenced via tag | `true`      |
 | `garbageCollect.schedule`   | CronTab schedule, please use standard crontab format                                       | `0 1 * * *`     |
+| `garbageCollect.podAnnotations` | CronJob pod Annotations. If left empty and chart `podAnnotations` are set, will use those. If both are set, these take precedence for the `garbageCollect` pods. | `{}` |
+| `garbageCollect.podLabels`  | CronJob pod Annotations. If left empty and chart `podLabels` are set, will use those. If both are set, these take precedence for the `garbageCollect` pods. | `{}` |
 | `garbageCollect.resources`  | garbage-collector requested resources                                                      | `{}`            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to


### PR DESCRIPTION
Update README.md for garbageCollect Annotations and Labels keys. This adds verbiage for the chart `podAnnotations` and `podLabels` as well as adding `garbageCollect.podAnnotations` and `garbageCollect.podLabels`. I missed this in the previous pull request.