### PR TITLE
Add the ability to force path style for s3 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ their default values.
 | `s3.rootdirectory`          | S3 prefix that is applied to allow you to segment data                                     | `nil`           |
 | `s3.encrypt`                | Store images in encrypted format                                                           | `nil`           |
 | `s3.secure`                 | Use HTTPS                                                                                  | `nil`           |
+| `s3.forcepathstyle`         | Use path-style addressing, needed for some s3 compatible storage (minio)                   | `nil`           |
 | `swift.authurl`             | Swift authurl                                                                              | `nil`           |
 | `swift.container`           | Swift container                                                                            | `nil`           |
 | `proxy.enabled`             | If true, registry will function as a proxy/mirror                                          | `false`         |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -103,6 +103,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   value: {{ .Values.s3.secure | quote }}
 {{- end -}}
 
+{{- if .Values.s3.forcepathstyle }}
+- name: REGISTRY_STORAGE_S3_FORCEPATHSTYLE
+  value: {{ .Values.s3.forcepathstyle | quote }}
+{{- end -}}
+
 {{- else if eq .Values.storage "swift" }}
 - name: REGISTRY_STORAGE_SWIFT_AUTHURL
   value: {{ required ".Values.swift.authurl is required" .Values.swift.authurl }}

--- a/values.yaml
+++ b/values.yaml
@@ -104,6 +104,7 @@ secrets:
 #   rootdirectory: /object/prefix
 #   encrypt: false
 #   secure: true
+#   forcepathstyle: true
 
 # Options for swift storage type:
 # swift:


### PR DESCRIPTION
Add ability to set the forcepathstyle value from the helm chart. This is needed to support certain s3 compatible applications.

Closes https://github.com/twuni/docker-registry.helm/issues/163