### PR TITLE
Use labels suggested by K8s and Helm best practices

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -23,6 +23,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "docker-registry.match-labels" -}}
+app: {{ template "docker-registry.name" . }}
+release: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "docker-registry.labels" -}}
+{{ include "docker-registry.match-labels" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+heritage: {{ .Release.Service }}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
 {{- define "docker-registry.envs" -}}
 - name: REGISTRY_HTTP_SECRET
   valueFrom:

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}-config
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{ include "docker-registry.labels" . | nindent 4 }}
 data:
   config.yml: |-
 {{ toYaml .Values.configData | indent 4 }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -5,17 +5,13 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}-garbage-collector
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{ include "docker-registry.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.garbageCollect.schedule | quote }}
   jobTemplate:
     metadata:
       labels:
-        app: {{ template "docker-registry.name" . }}
-        release: {{ .Release.Name }}
+        {{ include "docker-registry.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -29,7 +25,7 @@ spec:
       template:
         metadata:
           labels:
-            release: {{ .Release.Name }}
+            {{ include "docker-registry.labels" . | nindent 12 }}
             {{- if or .Values.podLabels .Values.garbageCollect.podLabels }}
             {{- toYaml (merge (.Values.garbageCollect.podLabels | default (dict)) (.Values.podLabels | default (dict))) | nindent 12 }}
             {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{ include "docker-registry.labels" . | nindent 4 }}
 {{- if .Values.deployment.annotations }}
   annotations:
 {{ toYaml .Values.deployment.annotations | indent 4 }}
@@ -15,8 +12,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "docker-registry.name" . }}
-      release: {{ .Release.Name }}
+      {{ include "docker-registry.match-labels" . | nindent 6 }}
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.updateStrategy }}
   strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
@@ -25,8 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "docker-registry.name" . }}
-        release: {{ .Release.Name }}
+        {{ include "docker-registry.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -6,10 +6,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "docker-registry.fullname" . }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{ include "docker-registry.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/templates/hpaV1.yaml
+++ b/templates/hpaV1.yaml
@@ -6,10 +6,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "docker-registry.fullname" . }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{ include "docker-registry.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -9,10 +9,7 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "docker-registry.labels" . | indent 4 }}
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}

--- a/templates/poddisruptionbudget.yaml
+++ b/templates/poddisruptionbudget.yaml
@@ -9,14 +9,10 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{ include "docker-registry.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "docker-registry.name" . }}
-      release: {{ .Release.Name }}
+{{ include "docker-registry.match-labels" . | indent 6 }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/templates/prometheusrules.yaml
+++ b/templates/prometheusrules.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}
   labels:
     app.kubernetes.io/component: controller
+    {{ include "docker-registry.labels" . | nindent 4 }}
   {{- if .Values.metrics.prometheusRule.labels }}
     {{- toYaml .Values.metrics.prometheusRule.labels | nindent 4 }}
   {{- end }}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -6,10 +6,7 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    app: {{ template "docker-registry.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{ include "docker-registry.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}-secret
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{ include "docker-registry.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.secrets.htpasswd }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "docker-registry.labels" . | indent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
@@ -48,5 +45,4 @@ spec:
       targetPort: {{ (split ":" .Values.configData.http.debug.addr)._1 }}
 {{- end }}
   selector:
-    app: {{ template "docker-registry.name" . }}
-    release: {{ .Release.Name }}
+    {{ include "docker-registry.match-labels" . | nindent 4 }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{ include "docker-registry.labels" . | nindent 4 }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
 {{- if .Values.serviceAccount.name }}
   name: {{ .Values.serviceAccount.name }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -4,17 +4,14 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "docker-registry.fullname" . }}-servicemonitor
   labels:
-    app: {{ template "docker-registry.name" . }}-metrics
-    release: {{ .Release.Name }}
+{{ include "docker-registry.labels" . | indent 4 }}
 {{- if .Values.metrics.serviceMonitor.labels }}
 {{ toYaml .Values.metrics.serviceMonitor.labels | indent 4 }}
 {{- end }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "docker-registry.name" . }}
-      release: {{ .Release.Name }}
-      heritage: {{ .Release.Service }}
+      {{ include "docker-registry.match-labels" . | nindent 6 }}
   endpoints:
   - port: http-metrics
     interval: 15s


### PR DESCRIPTION
This improves the compatibility and makes it easier to work with various tools, which take advantage from the assumption of existence of those labels.

    https://helm.sh/docs/chart_best_practices/labels/
    https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

Changing the selectors is breaking change, so the bump of the major version of the helm chart.