### PR TITLE
Image tag set to '' now leads to `image: "registry"` instead of image: `"registry:"`

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}{{ if not (empty .Values.image.tag) }}:{{ .Values.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - /bin/registry


### PR DESCRIPTION
Hi,

We need to use a non-tagged image as it's shipped in our nodes filesystem so updates of nodes doesn't require a synchronized update of deployment as we have to follow the shipped-only image.
With this PR, settings explicitly an empty value for image.tag also remove the leading `:`.
With any other values, functionality remains the same.