### PR TITLE
🏁 v3.0.0 Release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 2.3.0
-appVersion: 2.8.1
+version: 3.0.0
+appVersion: 3.0.0
 home: https://hub.docker.com/_/registry/
 icon: https://helm.twun.io/docker-registry.png
 maintainers:


### PR DESCRIPTION
This releases this chart against Docker Registry v3.

Full change set is viewable here: https://github.com/twuni/docker-registry.helm/compare/v2.3.0...main

This adds the following variables:
 - `configPath` - (needed to support v3)
 - `s3.forcepathstyle` - supports path-style addressing for s3-compatible storage
 - `s3.skipverify` - boolean, allows connection to s3 with untrusted TLS cert
