### PR TITLE
Expose enableServiceLinks to values

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ their default values.
 | `secrets.haSharedSecret`    | Shared secret for Registry                                                                 | `nil`           |
 | `configData`                | Configuration hash for docker                                                              | `nil`           |
 | `configPath` | Configuration mount point in docker, `/etc/docker/registry` for registry version 2, `/etc/distribution` for version 3 | `/etc/docker/registry` |
+| `enableServiceLinks`        | Whether or not to enable service links                                                     | `true`          |
 | `s3.region`                 | S3 region                                                                                  | `nil`           |
 | `s3.regionEndpoint`         | S3 region endpoint                                                                         | `nil`           |
 | `s3.bucket`                 | S3 bucket name                                                                             | `nil`           |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -88,6 +88,7 @@ spec:
           securityContext: {{ omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts: {{ include "docker-registry.volumeMounts" . | nindent 12 }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -174,6 +174,8 @@ containerSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
+enableServiceLinks: true
+
 securityContext:
   enabled: true
   fsGroupChangePolicy: Always


### PR DESCRIPTION
Some deployments of the Helm Chart would want to explicitly disable [Service Links](https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service) for potential performance implications (https://dev.to/matthewdailey/post-mortem-kubernetes-pods-dont-start-because-of-too-many-services-1129).

This PR exposes the `enableServiceLinks` variable, defaulting to `true` (the same default as per K8s [documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/)).