### PR TITLE
Update README with repo migration notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This chart will do the following:
 First, add the repo:
 
 ```console
-helm repo add twuni https://helm.twun.io
+helm repo add twuni https://twuni.github.io/docker-registry.helm
 ```
 
 To install the chart, use the following:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ This chart will do the following:
 
 * Implement a Docker registry deployment
 
+## ⚠️ Repo Migration and Deprecation Notice
+
+The following change only affects attempts to install or update the chart via the https://helm.twun.io repo.
+
+The https://helm.twun.io repo has been migrated to https://twuni.github.io/docker-registry.helm.
+
+To update your configuration, remove and re-add the repo with the new URL:
+
+```console
+helm repo remove twuni
+helm repo add twuni https://twuni.github.io/docker-registry.helm
+```
+
+The deprecated repo URL, https://helm.twun.io, may become unavailable as early as **October 16, 2025**.
+
 ## Installing the Chart
 
 First, add the repo:


### PR DESCRIPTION
GitHub Pages has been the primary distribution channel for this chart since [March 2024](https://github.com/twuni/docker-registry.helm/issues/67#issuecomment-1993575846).

The README has not yet been updated to reflect this change.

Until now!

I have also included a formal deprecation notice and migration instructions for folks still using the https://helm.twun.io repo. Now that we have a functional GitHub Pages distribution channel, I would like to remove support for the old Helm repo at some point. I also don't want to be a jerk and pull the rug without sufficient notice.

The twun.io domain expires on October 16, 2025, and I am debating whether to renew it. While I haven't made a decision, yet, this PR gives me the potential option to let it expire rather than paying the $70 renewal cost.

I realize changing the repo URL or allowing the domain to potentially fall into the hands of a malicious actor is a risk. I'm willing to entertain alternatives, suggestions, or donations to maintain continuity.
