### PR TITLE
feat: existing secret support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 3.0.0
-appVersion: 3.0.0
+version: 3.1.0
+appVersion: 3.1.0
 home: https://hub.docker.com/_/registry/
 icon: https://helm.twun.io/docker-registry.png
 maintainers:
-- email: devin@canterberry.cc
-  name: Devin Canterberry
-  url: https://canterberry.cc/
+  - email: devin@canterberry.cc
+    name: Devin Canterberry
+    url: https://canterberry.cc/
 sources:
-- https://github.com/docker/distribution-library-image
+  - https://github.com/docker/distribution-library-image

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ their default values.
 | `priorityClassName      `   | priorityClassName                                                                          | `""`            |
 | `storage`                   | Storage system to use                                                                      | `filesystem`    |
 | `tlsSecretName`             | Name of secret for TLS certs                                                               | `nil`           |
+| `existingSecret`            | Name of an existing secret to use instead of creating one                                  | `""`            |
 | `secrets.htpasswd`          | Htpasswd authentication                                                                    | `nil`           |
 | `secrets.s3.accessKey`      | Access Key for S3 configuration                                                            | `nil`           |
 | `secrets.s3.secretKey`      | Secret Key for S3 configuration                                                            | `nil`           |

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -17,3 +17,9 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8080:5000
 {{- end }}
+
+{{- if .Values.existingSecret }}
+
+NOTE: You are using an existing secret "{{ .Values.existingSecret }}" for registry credentials.
+Ensure it contains required keys for your chosen auth/storage/proxy configuration.
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -23,11 +23,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "docker-registry.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{- .Values.existingSecret -}}
+{{- else -}}
+{{- template "docker-registry.fullname" . }}-secret
+{{- end -}}
+{{- end -}}
+
 {{- define "docker-registry.envs" -}}
 - name: REGISTRY_HTTP_SECRET
   valueFrom:
     secretKeyRef:
-      name: {{ template "docker-registry.fullname" . }}-secret
+      name: {{ template "docker-registry.secretName" . }}
       key: haSharedSecret
 
 {{- if .Values.secrets.htpasswd }}
@@ -53,17 +61,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 - name: REGISTRY_STORAGE_AZURE_ACCOUNTNAME
   valueFrom:
     secretKeyRef:
-      name: {{ template "docker-registry.fullname" . }}-secret
+      name: {{ template "docker-registry.secretName" . }}
       key: azureAccountName
 - name: REGISTRY_STORAGE_AZURE_ACCOUNTKEY
   valueFrom:
     secretKeyRef:
-      name: {{ template "docker-registry.fullname" . }}-secret
+      name: {{ template "docker-registry.secretName" . }}
       key: azureAccountKey
 - name: REGISTRY_STORAGE_AZURE_CONTAINER
   valueFrom:
     secretKeyRef:
-      name: {{ template "docker-registry.fullname" . }}-secret
+      name: {{ template "docker-registry.secretName" . }}
       key: azureContainer
 {{- else if eq .Values.storage "s3" }}
 - name: REGISTRY_STORAGE_S3_REGION
@@ -74,12 +82,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 - name: REGISTRY_STORAGE_S3_ACCESSKEY
   valueFrom:
     secretKeyRef:
-      name: {{ if .Values.secrets.s3.secretRef }}{{ .Values.secrets.s3.secretRef }}{{ else }}{{ template "docker-registry.fullname" . }}-secret{{ end }}
+      name: {{ if .Values.secrets.s3.secretRef }}{{ .Values.secrets.s3.secretRef }}{{ else }}{{ template "docker-registry.secretName" . }}{{ end }}
       key: s3AccessKey
 - name: REGISTRY_STORAGE_S3_SECRETKEY
   valueFrom:
     secretKeyRef:
-      name: {{ if .Values.secrets.s3.secretRef }}{{ .Values.secrets.s3.secretRef }}{{ else }}{{ template "docker-registry.fullname" . }}-secret{{ end }}
+      name: {{ if .Values.secrets.s3.secretRef }}{{ .Values.secrets.s3.secretRef }}{{ else }}{{ template "docker-registry.secretName" . }}{{ end }}
       key: s3SecretKey
 {{- end -}}
 
@@ -119,12 +127,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 - name: REGISTRY_STORAGE_SWIFT_USERNAME
   valueFrom:
     secretKeyRef:
-      name: {{ template "docker-registry.fullname" . }}-secret
+      name: {{ template "docker-registry.secretName" . }}
       key: swiftUsername
 - name: REGISTRY_STORAGE_SWIFT_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ template "docker-registry.fullname" . }}-secret
+      name: {{ template "docker-registry.secretName" . }}
       key: swiftPassword
 - name: REGISTRY_STORAGE_SWIFT_CONTAINER
   value: {{ required ".Values.swift.container is required" .Values.swift.container }}
@@ -136,12 +144,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 - name: REGISTRY_PROXY_USERNAME
   valueFrom:
     secretKeyRef:
-      name: {{ if .Values.proxy.secretRef }}{{ .Values.proxy.secretRef }}{{ else }}{{ template "docker-registry.fullname" . }}-secret{{ end }}
+      name: {{ if .Values.proxy.secretRef }}{{ .Values.proxy.secretRef }}{{ else }}{{ template "docker-registry.secretName" . }}{{ end }}
       key: proxyUsername
 - name: REGISTRY_PROXY_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ if .Values.proxy.secretRef }}{{ .Values.proxy.secretRef }}{{ else }}{{ template "docker-registry.fullname" . }}-secret{{ end }}
+      name: {{ if .Values.proxy.secretRef }}{{ .Values.proxy.secretRef }}{{ else }}{{ template "docker-registry.secretName" . }}{{ end }}
       key: proxyPassword
 {{- end -}}
 
@@ -191,7 +199,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.secrets.htpasswd }}
 - name: auth
   secret:
-    secretName: {{ template "docker-registry.fullname" . }}-secret
+    secretName: {{ template "docker-registry.secretName" . }}
     items:
     - key: htpasswd
       path: htpasswd

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -21,7 +21,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -32,7 +32,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{ toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -38,3 +39,4 @@ data:
   {{- end }}
   proxyUsername: {{ .Values.proxy.username | default "" | b64enc | quote }}
   proxyPassword: {{ .Values.proxy.password | default "" | b64enc | quote }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,11 @@
 # Default values for docker-registry.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# If set, use an existing Secret instead of creating one
+# The existing secret must contain the expected keys (haSharedSecret, htpasswd, storage/provider keys, proxy credentials as applicable)
+# existingSecret: ""
+
 replicaCount: 1
 
 updateStrategy: {}


### PR DESCRIPTION
This pull request adds support for using an existing Kubernetes Secret for Docker Registry credentials and configuration, instead of always creating a new one. This makes it easier to manage secrets externally and improves flexibility for deployments. The documentation, templates, and values have all been updated to reflect this new option.

Key changes include:

**Support for Existing Secret:**
* Added a new `existingSecret` value in `values.yaml` and documented its usage in `README.md`, allowing users to specify the name of a pre-existing Kubernetes Secret for registry credentials. [[1]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR4-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74)
* Updated all secret references in `_helpers.tpl` to use the new `docker-registry.secretName` template, which chooses between the existing secret and the default generated secret. [[1]](diffhunk://#diff-87d68c754766af8e2e930e653be7e4b75fa0c8bdb187cb1bec293f265d9159ffR26-R38) [[2]](diffhunk://#diff-87d68c754766af8e2e930e653be7e4b75fa0c8bdb187cb1bec293f265d9159ffL56-R74) [[3]](diffhunk://#diff-87d68c754766af8e2e930e653be7e4b75fa0c8bdb187cb1bec293f265d9159ffL77-R90) [[4]](diffhunk://#diff-87d68c754766af8e2e930e653be7e4b75fa0c8bdb187cb1bec293f265d9159ffL122-R135) [[5]](diffhunk://#diff-87d68c754766af8e2e930e653be7e4b75fa0c8bdb187cb1bec293f265d9159ffL139-R152) [[6]](diffhunk://#diff-87d68c754766af8e2e930e653be7e4b75fa0c8bdb187cb1bec293f265d9159ffL194-R202)

**Template and Resource Adjustments:**
* Modified `secret.yaml` to only create a new Secret if `existingSecret` is not set, preventing duplicate or unnecessary secrets. [[1]](diffhunk://#diff-8b770fd33a2766d14d83793af8a8fdbd9a7774d7a71253ef2be15abd772cd00fR1) [[2]](diffhunk://#diff-8b770fd33a2766d14d83793af8a8fdbd9a7774d7a71253ef2be15abd772cd00fR42)
* Updated `deployment.yaml` and `cronjob.yaml` to only annotate with the secret checksum when a new secret is created, ensuring correct rolling updates. [[1]](diffhunk://#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38R35-R37) [[2]](diffhunk://#diff-e318d7eea75d50ac224c7bdad816df4e3e17578b586f0a13a29c66c2fe73d737R24-R26)
* Added a note in `NOTES.txt` to inform users when an existing secret is being used, with a reminder about required keys.

**Version Bump:**
* Bumped chart and app versions to `3.1.0` to reflect the new feature.