### PR TITLE
feat: permit cronjob pod to have its own affinity

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -72,7 +72,9 @@ spec:
           {{- if .Values.nodeSelector }}
           nodeSelector: {{ toYaml .Values.nodeSelector | nindent 12 }}
           {{- end }}
-          {{- if .Values.affinity }}
+          {{- if .Values.garbageCollect.affinity }}
+          affinity: {{ toYaml .Values.garbageCollect.affinity | nindent 12 }}
+          {{- else if .Values.affinity }}
           affinity: {{ toYaml .Values.affinity | nindent 12 }}
           {{- end }}
           {{- if .Values.tolerations }}


### PR DESCRIPTION
Make it possible for the garbage collector cronjob to have its own affinity parameters.
Fallback to previous behavior when garbageCollect.affinity is absent